### PR TITLE
error al desplegar y css del muro

### DIFF
--- a/src/components/muro.js
+++ b/src/components/muro.js
@@ -76,7 +76,7 @@ export const muro = (onNavigate) => {
         const objectoAccion = new Date(time * 1000);
         // Condicional que dice que si el usuario logeado es el mismo que escribió el
         // post que muestre las templates.
-        if (dataPost.userUid === currentUser().uid) {
+        if (currentUser() && dataPost.userUid === currentUser().uid) {
           html += `
             <div class = 'publicaciones'>
             <p class='datePost'>${objectoAccion}</p>

--- a/src/main.css
+++ b/src/main.css
@@ -237,7 +237,7 @@ p {
     flex-direction: column;
     align-items: center;
     background: var(--melon);
-    height: 1400px;
+    margin-bottom:40px ;
 }
 
 .iconsPostDiv {


### PR DESCRIPTION
Aquí el hemos modificado el current user, para que cargue el muro cuando el usuario esta logeado y asi evitar el error que nos salía al desplegar. También agregamos unas modificaciiones que nos permiten ver que el color de fondo cubre todo el muro.